### PR TITLE
feat: Add Haskell libs (WPB-6142)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -90,6 +90,9 @@
               http-client-tls
               servant
               servant-client
+              text
+              bytestring
+              base64-bytestring
               optparse-applicative
             ]);
         };

--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,7 @@
               foldl
               aeson
               http-client
+              http-client-tls
               servant
               servant-client
               optparse-applicative

--- a/flake.nix
+++ b/flake.nix
@@ -89,6 +89,7 @@
               http-client
               servant
               servant-client
+              optparse-applicative
             ]);
         };
         devshells = {

--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,8 @@
               foldl
               aeson
               http-client
+              servant
+              servant-client
             ]);
         };
         devshells = {


### PR DESCRIPTION
# What's new in this PR?

Add Haskell libs for text processing (`bytestring`, `text`), making HTTP requests (`servant`) and parsing cli options (`optparse-applicative`.) These are used to issue calls to the Dependency tracker: https://github.com/wireapp/wire-server/pull/3810 